### PR TITLE
Removing -v from adb shell rm

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -89,7 +89,7 @@ then
   cecho "Exporting contacts (as vCard)."
   adb pull /storage/emulated/0/linux-android-backup-temp ./backup-tmp/Contacts
   cecho "Removing temporary files created by the companion app."
-  adb shell rm -rfv /storage/emulated/0/linux-android-backup-temp
+  adb shell rm -rf /storage/emulated/0/linux-android-backup-temp
 
   # Export internal storage
   cecho "Exporting internal storage - this will take a while."


### PR DESCRIPTION
On my device (Android 8.1), rm doesn't have a -v switch and the script will abort with 
```
Removing temporary files created by the companion app.
See rm --help
rm: Unknown option v
```
From my device 
```
> adb shell rm --help
usage: rm [-fiRr] FILE...

Remove each argument from the filesystem.

-f      force: remove without confirmation, no error if it doesn't exist
-i      interactive: prompt for confirmation
-rR     recursive: remove directory contents
```